### PR TITLE
fix: check-auth endpoint

### DIFF
--- a/backend/app/main/routes.py
+++ b/backend/app/main/routes.py
@@ -24,7 +24,7 @@ def refresh():
     return response
 
 
-@bp.route('/check-auth', methods=['POST'])
+@bp.route('/check-auth', methods=['GET'])
 @jwt_required()
 def check_auth():
     identity = get_jwt_identity()
@@ -32,4 +32,3 @@ def check_auth():
     if not user:
         response = make_response({'errors': [{'msg': 'User not found'}]}, 401)
         return response
-    return 200


### PR DESCRIPTION
Replaced type of method to GET. Fixed answer type

Return 200 IF OK
Return 401 {'errors': [{'msg': 'User not found'}] IF NOT OK